### PR TITLE
Add pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/env bash
+
+for DATASET_ARCHIVE in $(git diff --name-only --staged -- '*.zip'); do
+	ARCHIVE_FILES=$(zipinfo -1 "$DATASET_ARCHIVE")
+	ARCHIVE_CONTENTS_FILE="${DATASET_ARCHIVE%.zip}.txt"
+	echo "$ARCHIVE_FILES" >"$ARCHIVE_CONTENTS_FILE"
+	git add "$ARCHIVE_CONTENTS_FILE"
+done

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 Here lie the datasets for the [Desbordante](https://github.com/Mstrutov/Desbordante) platform.
 
 You can check the contents in the corresponding `.txt` files -- they are automatically generated from the zip-archives via git-hooks. 
+
+## Hooks
+
+To keep dataset lists up-to-date, it is recommended to set up the pre-commit hook, which will
+automatically update dataset lists:
+```bash
+chmod +x .githooks/pre-commit && ln -sv ../../.githooks/pre-commit .git/hooks/pre-commit
+```
+
+Due to git limitations, generated `.txt` files won't be listed in commit message editor, but they will be tracked.


### PR DESCRIPTION
Add script that can be used as git pre-commit hook to list `.zip` archives contents.
This PR is needed for https://github.com/Desbordante/desbordante-core/issues/603.